### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,3 +40,19 @@ p6df::modules::graphql::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words graphql $GRAPHQL_ENDPOINT = p6df::modules::graphql::profile::mod()
+#
+#  Returns:
+#	words - graphql $GRAPHQL_ENDPOINT
+#
+#  Environment:	 GRAPHQL_ENDPOINT
+#>
+######################################################################
+p6df::modules::graphql::profile::mod() {
+
+  p6_return_words 'graphql' '$GRAPHQL_ENDPOINT'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -54,5 +54,5 @@ p6df::modules::graphql::external::brews() {
 ######################################################################
 p6df::modules::graphql::profile::mod() {
 
-  p6_return_words 'graphql' '$GRAPHQL_ENDPOINT'
+  p6_return_words 'graphql' "$"
 }


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None