### PR TITLE
fix(profile): remove broken profile::mod with empty env var

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,19 +40,3 @@ p6df::modules::graphql::external::brews() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words graphql $GRAPHQL_ENDPOINT = p6df::modules::graphql::profile::mod()
-#
-#  Returns:
-#	words - graphql $GRAPHQL_ENDPOINT
-#
-#  Environment:	 GRAPHQL_ENDPOINT
-#>
-######################################################################
-p6df::modules::graphql::profile::mod() {
-
-  p6_return_words 'graphql' "$"
-}


### PR DESCRIPTION
## What
Remove the `p6df::modules::graphql::profile::mod` function entirely, as it contained a broken `"$"` placeholder instead of a real env var reference.

## Why
The function was non-functional — it called `p6_return_words 'graphql' "$"` with a bare `"$"` that expands to nothing. Removing it is cleaner than leaving a broken stub. If a real `GRAPHQL_ENDPOINT` integration is needed in the future, it can be added properly.

## Test plan
- Reviewed diff; removes 16 lines of dead/broken code
- No functional regressions expected since the function never worked correctly

## Dependencies
None