### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::graphql::deps()
-#
-#>
-######################################################################
 p6df::modules::graphql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -13,11 +7,12 @@ p6df::modules::graphql::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::graphql::vscodes()
-#
-#>
+p6df::modules::graphql::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install --cask graphiql
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::graphql::vscodes() {
 
@@ -30,13 +25,18 @@ p6df::modules::graphql::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::graphql::external::brews()
+# Function: p6df::modules::graphql::deps()
 #
 #>
 ######################################################################
-p6df::modules::graphql::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install --cask graphiql
-
-  p6_return_void
-}
+#<
+#
+# Function: p6df::modules::graphql::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::graphql::external::brews()
+#
+#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::graphql::deps()
+#
+#>
+######################################################################
 p6df::modules::graphql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -7,12 +13,24 @@ p6df::modules::graphql::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::graphql::external::brews()
+#
+#>
+######################################################################
 p6df::modules::graphql::external::brews() {
 
   p6df::core::homebrew::cli::brew::install --cask graphiql
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::graphql::vscodes()
+#
+#>
 ######################################################################
 p6df::modules::graphql::vscodes() {
 
@@ -22,21 +40,3 @@ p6df::modules::graphql::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::graphql::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::graphql::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::graphql::external::brews()
-#
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None